### PR TITLE
Update for JDK 11

### DIFF
--- a/deps/wrapping/main.go
+++ b/deps/wrapping/main.go
@@ -17,8 +17,8 @@
 // Package main exposes APIs from the mapping library to other languages with CGO.
 package main
 
-//#cgo CFLAGS: -I/usr/lib/jvm/java-8-openjdk-amd64/include/
-//#cgo CFLAGS: -I/usr/lib/jvm/java-8-openjdk-amd64/include/linux/
+//#cgo CFLAGS: -I/usr/lib/jvm/java-11-openjdk-amd64/include/
+//#cgo CFLAGS: -I/usr/lib/jvm/java-11-openjdk-amd64/include/linux/
 //#cgo LDFLAGS: mapping_util.o
 /*
 #include "../clib/mapping_util.h"


### PR DESCRIPTION
Fixes #12

Commit c9abd2a updated build_deps.sh to install and use JDK 11. Building the shadow jar failed to find jni.h because Go was attempting to include the file from a JDK 8 location.